### PR TITLE
Fix duplicate rrd charts

### DIFF
--- a/share/check_mk/web/plugins/metrics/access_logs.py
+++ b/share/check_mk/web/plugins/metrics/access_logs.py
@@ -133,7 +133,7 @@ metric_info["failure_rate"] = {
     "color" : "14/a",
 }
 
-graph_info.append({
+graph_info['count'] = {
    "title"         : ("HTTP Response Status Codes"),
    "metrics"       : [
                         ( "count_no_status", "area" ),
@@ -156,14 +156,14 @@ graph_info.append({
                         ( "count_101", "stack")
                      ],
     "omit_zero_metrics" : True,
-})
+}
 
-graph_info.append({
+graph_info['failure_rate] = {
    "title"         : ("HTTP Failure Rate"),
    "metrics"       : [
                         ( "failure_rate", "line")
                      ],
     "omit_zero_metrics" : True,
-})
+}
 
 


### PR DESCRIPTION
Fix issue #4. Not sure why but Checkmk doesn't seem to like `graph_info.append()`. Normally it should work the same as naming the `graph_info` like I do, see https://forum.checkmk.com/t/custom-check-and-graph-template/21067/2, but for some reason it doesn't, might be an issue with Checkmk, unsure.